### PR TITLE
Fix Modbus reading issue when the number of registers to read is bigger than the maximum number of registers per Modbus request

### DIFF
--- a/modbus-parsers/src/main/java/nl/basjes/modbus/ModBusDataReader.java
+++ b/modbus-parsers/src/main/java/nl/basjes/modbus/ModBusDataReader.java
@@ -174,13 +174,14 @@ public class ModBusDataReader implements AutoCloseable {
 
     public byte[] getRawRegisterBytes(int base, int len) throws ModbusException {
         byte[] bytes = new byte[len * 2];
-
+        int newBase=base;   
         int i = 0;
         int remaining = len;
         while (remaining > 0) {
             int readSize = Math.min(remaining, maxRegistersPerModbusRequest);
             remaining -= readSize;
-            final InputRegister[] registers = read(base, readSize);
+            final InputRegister[] registers = read(newBase, readSize);
+            newBase=base+readSize;
             for (InputRegister register : registers) {
                 byte[] registerBytes = register.toBytes();
                 bytes[i++] = registerBytes[0];


### PR DESCRIPTION
Fixes #307 